### PR TITLE
Enable CRM tests with mock artifact

### DIFF
--- a/crm/mock.ts
+++ b/crm/mock.ts
@@ -38,7 +38,7 @@ export function createMockFetch(mockData: Map<string, MoneyworksRecord[]>) {
     const mwTime = searchParam.match(/\d{14}/)?.[0]
     const since = mwTime ? parseMoneyworksTime(mwTime) : 0
     const rows = mockData.get(table) ?? []
-    const filtered = rows.filter((r) => r.lastModified >= since)
+    const filtered = rows.filter((r) => r.lastModified > since)
     const xmlOutput = stringifyXmlRecords(table, filtered)
     return new Response(xmlOutput, { status: 200 })
   }


### PR DESCRIPTION
## Summary
- unignore CRM tests
- mock artifact server in tests
- tweak mock Moneyworks server export filter
- fix branch provisioning logic
- avoid unnecessary commits in `reconcile`

## Testing
- `deno task ok`

------
https://chatgpt.com/codex/tasks/task_e_6861b660db34832b8911b6507f2111f2